### PR TITLE
changes erspan binding for monitor common header

### DIFF
--- a/scapy/contrib/vxlan.py
+++ b/scapy/contrib/vxlan.py
@@ -31,17 +31,6 @@ class VXLAN_GPE(Packet):
 
     def mysummary(self):
         return self.sprintf("VXLAN_GPE (vni=%VXLAN_GPE.vni%)")
-    
-    def guess_payload_class(self, payload):                                                                                           
-        if self.next_proto == 0x5:
-            # VXLAN_GPE_INT or INT_PLT
-            int_type = ord(payload[0])
-            if int_type == 1 or int_type == 2:
-                return VXLAN_GPE_INT
-            elif int_type == 3:
-                return VXLAN_GPE_INT_PLT
-        else:
-            return Packet.guess_payload_class(self, payload)
  
 bind_layers(UDP, VXLAN_GPE, dport=4790)
 bind_layers(VXLAN_GPE, Ether, next_proto=3)

--- a/scapy/contrib/xnt.py
+++ b/scapy/contrib/xnt.py
@@ -7,6 +7,9 @@ from scapy.packet import *
 from scapy.fields import *
 from scapy.all import * # Otherwise failing at the UDP reference below
 
+ERSPAN_INT_SESSION_ID = 0x10
+ERSPAN_MOD_SESSION_ID = 0x11
+
 class VXLAN_GPE_INT_PLT(Packet):
     name = "VXLAN_GPE_INT_PLT_header"
     fields_desc = [ XByteField("int_type", 0x03),
@@ -64,9 +67,7 @@ class INT_META_HDR(Packet):
                     ShortField("rsvd2", 0x0000)]
 
 bind_layers(VXLAN_GPE_INT, INT_META_HDR)
-bind_layers(ERSPAN_III, INT_META_HDR, sgt_other=0x4000)  # this for the INT upstream report from sink
-bind_layers(ERSPAN_III, INT_META_HDR, sgt_other=0x4008)  # this for the INT last-hop report from sink
-bind_layers(ERSPAN_III, INT_META_HDR, sgt_other=0x4408)  # this for the INT last-hop report from 1-hop sink, which is INT src and sink at the same time for local traffic
+bind_layers(ERSPAN_III, INT_META_HDR, span_id=ERSPAN_INT_SESSION_ID)  # this for the INT report from sink
 # Add binding to GENEVE
 bind_layers(GENEVE_INT, INT_META_HDR)
 

--- a/scapy/contrib/xnt.py
+++ b/scapy/contrib/xnt.py
@@ -8,7 +8,6 @@ from scapy.fields import *
 from scapy.all import * # Otherwise failing at the UDP reference below
 
 ERSPAN_INT_SESSION_ID = 0x10
-ERSPAN_MOD_SESSION_ID = 0x11
 
 class VXLAN_GPE_INT_PLT(Packet):
     name = "VXLAN_GPE_INT_PLT_header"


### PR DESCRIPTION
This is the change required for the common header of reports to the monitor from data plane. 
The erspan.span_id is now separated from mirror_session_id. This indirection is configurable through a mapping (mirror_session_id -> erspan_span_id) by user when creating mirror interface (passing erspan tunnel info). I chose to use one erspan_span_id for all INT cases. Different cases (up, down, 1hop) are identifiable through erspan.ft_d_other (frame_type and direction)

Review @arielt @srikrishnagopu 